### PR TITLE
Convert locale to use - instead of _ from symfony

### DIFF
--- a/src/Type/BasePickerType.php
+++ b/src/Type/BasePickerType.php
@@ -253,7 +253,7 @@ abstract class BasePickerType extends AbstractType implements LocaleAwareInterfa
                 'theme' => 'light',
             ],
             'localization' => [
-                'locale' => $this->locale,
+                'locale' => str_replace('_', '-', $this->locale),
             ],
         ];
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Symfony does use country specific locales like `de_CH`. Js on the other hand uses `de-CH`. This results in a js issue here, since `datepicker_controller.js` only splits by `-`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/form-extensions/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the change fixes a bug and keeps BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/form-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added

### Changed

### Deprecated

### Removed

### Fixed
- Country specific locale issues (convert de_CH to de-CH)

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
